### PR TITLE
Update React to 0.14.2 and Switch Reactify to Babelify

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["es2015", "react"]
-}

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "watch": "watchify src/imager.jsx -s imager.jsx -o dist/bundle.js"
   },
   "browserify": {
-    "transform": ["babelify"]
+    "transform": [
+      ["babelify", { "presets": ["es2015", "react"] }]
+    ]
   },
   "keywords": [
     "imager",

--- a/package.json
+++ b/package.json
@@ -9,21 +9,13 @@
   },
   "scripts": {
     "build": "npm run build-vendor && npm run build-bundle",
-    "build-vendor": "browserify -r react -o dist/vendor.js",
-    "build-bundle": "browserify -x react src/imager.jsx -s imager.jsx -o dist/bundle.js",
+    "build-vendor": "browserify -o dist/vendor.js",
+    "build-bundle": "browserify src/imager.jsx -s imager.jsx -o dist/bundle.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "watchify -x react src/imager.jsx -s imager.jsx -o dist/bundle.js"
+    "watch": "watchify src/imager.jsx -s imager.jsx -o dist/bundle.js"
   },
   "browserify": {
-    "transform": [
-      [
-        "reactify",
-        {
-          "es6": true,
-          "target": "es5"
-        }
-      ]
-    ]
+    "transform": ["babelify"]
   },
   "keywords": [
     "imager",
@@ -36,12 +28,15 @@
   "author": "Thomas Parisot (https://oncletom.io)",
   "license": "MIT",
   "dependencies": {
-    "imager.js": "^0.4.0",
-    "react": "^0.12.1"
+    "imager.js": "^0.5.0",
+    "react": "^0.14.2",
+    "react-dom": "^0.14.2"
   },
   "devDependencies": {
-    "browserify": "^6.3.2",
-    "reactify": "^0.17.1",
-    "watchify": "^2.1.1"
+    "babel-preset-es2015": "^6.1.18",
+    "babel-preset-react": "^6.1.18",
+    "babelify": "^7.2.0",
+    "browserify": "^12.0.1",
+    "watchify": "^3.6.0"
   }
 }

--- a/src/imager.jsx
+++ b/src/imager.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var Imager = require('imager.js');
 
 /**
@@ -88,7 +89,7 @@ module.exports = function (config) {
     },
 
     refreshImageWidth: function () {
-      var node = this.getDOMNode();
+      var node = ReactDOM.findDOMNode(this);
       var height = node.offsetHeight;
       var width = imgr.determineAppropriateResolution(node);
 


### PR DESCRIPTION
I've updated React to 0.14.2, and removed the deprecated `getDOMNode` method in favour of the new `findDOMNode` from ReactDOM. I also switched out Reactify for Babelify, as it seems as if reactify is no longer maintained.

It's probably a good idea to change the major version number also, seeing as React 0.14.2 might cause some breakages.

Thanks in advance!
